### PR TITLE
Support for feitian HW tokens

### DIFF
--- a/Controller/Component/Auth/GoogleAuthenticate.php
+++ b/Controller/Component/Auth/GoogleAuthenticate.php
@@ -39,7 +39,8 @@ class GoogleAuthenticate extends BaseAuthenticate {
 			'username' => 'username',
 			'password' => 'password',
 			'code' => 'code',
-			'secret' => 'secret'
+			'secret' => 'secret',
+                        'type' => 'tokentype'
 		),
 		'userModel' => 'User',
 		'scope' => array(),
@@ -100,7 +101,7 @@ class GoogleAuthenticate extends BaseAuthenticate {
 
 		$Google = new GoogleAuthenticator();
 
-		return $Google->checkCode($user[$fields['secret']], $request->data[$model][$fields['code']]) ? $user : false;
+		return $Google->checkCode($user[$fields['secret']], $request->data[$model][$fields['code']], $user[$fields['type']]) ? $user : false;
 	}
 
 }


### PR DESCRIPTION
Tested with C200

We have modified the code to support Feitian TOTP hardware tokens. (basic)

Added a field named type, this holds the token type eg "google", "feitian". This field used to check which method should be used for getting the right code.

Feitian uses 20byte Hexadecimal strings for secret. (by default). There are many other options, but only the default secret format is implemented here. [Description here](http://www.ftsafe.com/product/otp/totp)

If you interested in this, feel free to accept, comment, deny.
